### PR TITLE
Allow running outside of installation directory.

### DIFF
--- a/inference/model_runners.py
+++ b/inference/model_runners.py
@@ -21,6 +21,7 @@ import util
 from hydra.core.hydra_config import HydraConfig
 from rf2aa.model import RoseTTAFoldModel
 
+import os
 import sys
 sys.path.append('../') # to access RF structure prediction stuff 
 
@@ -53,6 +54,11 @@ class Sampler:
 
         # Initialize inference only helper objects to Sampler
         self.ckpt_path = conf.inference.ckpt_path
+        if not os.path.exists( self.ckpt_path ):
+            # Look for it in directory above this file
+            alt_path = os.path.join( os.path.dirname(os.path.dirname(os.path.abspath(__file__))), self.ckpt_path )
+            if os.path.exists( alt_path ):
+                self.ckpt_path = alt_path
 
         if needs_model_reload:
             # Load checkpoint, so that we can assemble the config

--- a/run_inference.py
+++ b/run_inference.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 """
 Inference script.
 
@@ -179,7 +180,8 @@ def save_outputs(sampler, out_prefix, indep, denoised_xyz_stack, px0_xyz_stack, 
     # Save outputs
     out_head, out_tail = os.path.split(out_prefix)
     unidealized_dir = os.path.join(out_head, 'unidealized')
-    os.makedirs(out_head, exist_ok=True)
+    if len(out_head) > 0:
+        os.makedirs(out_head, exist_ok=True)
     os.makedirs(unidealized_dir, exist_ok=True)
 
     # pX0 last step
@@ -195,7 +197,10 @@ def save_outputs(sampler, out_prefix, indep, denoised_xyz_stack, px0_xyz_stack, 
     des_path = os.path.abspath(out_idealized)
 
     # trajectory pdbs
-    traj_prefix = os.path.dirname(out_prefix)+'/traj/'+os.path.basename(out_prefix)
+    out_prefix_dirname = os.path.dirname(out_prefix)
+    if len(out_prefix_dirname) == 0:
+        out_prefix_dirname = '.'
+    traj_prefix = out_prefix_dirname+'/traj/'+os.path.basename(out_prefix)
     os.makedirs(os.path.dirname(traj_prefix), exist_ok=True)
 
     out = f'{traj_prefix}_Xt-1_traj.pdb'


### PR DESCRIPTION
Alter the checkpoint finding code to search in the installation directory in addition to the currently running directory.

Related, allow output_prefix to not include a directory (so output files are placed in the current directory.)